### PR TITLE
Test style.fontWeight before using it

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -443,8 +443,9 @@ function matchStyles(node, delta) {
     formats.italic = true;
   }
   if (
-    style.fontWeight.startsWith('bold') ||
-    parseInt(style.fontWeight, 10) >= 700
+    style.fontWeight &&
+    (style.fontWeight.startsWith('bold') ||
+      parseInt(style.fontWeight, 10) >= 700)
   ) {
     formats.bold = true;
   }


### PR DESCRIPTION
Using clipboard.dangerouslyPasteHTML() to manipulate the content of the editor with values as added by the kaTeX input fails because "style" in this case is just an "empty" object {} and has no style.fontWeight.
It fails when it processes elements like: 
`<mn>1</mn>`